### PR TITLE
Can revises entity with non public access modifier

### DIFF
--- a/source/AutoReviser.Tests/ImmutableExtensions_specs.cs
+++ b/source/AutoReviser.Tests/ImmutableExtensions_specs.cs
@@ -46,6 +46,40 @@
             public ComplexImmutableObject Golf { get; }
         }
 
+        public class ImmutableObjectWithInternalConstuctor
+        {
+            internal ImmutableObjectWithInternalConstuctor(
+                Guid alfa, int bravo, SimpleImmutableObject charlie)
+            {
+                Alfa = alfa;
+                Bravo = bravo;
+                Charlie = charlie;
+            }
+
+            public Guid Alfa { get; }
+
+            public int Bravo { get; }
+
+            public SimpleImmutableObject Charlie { get; }
+        }
+
+        public class ImmutableObjectWithInternalProperties
+        {
+            public ImmutableObjectWithInternalProperties(
+                Guid alfa, int bravo, SimpleImmutableObject charlie)
+            {
+                Alfa = alfa;
+                Bravo = bravo;
+                Charlie = charlie;
+            }
+
+            internal Guid Alfa { get; }
+
+            internal int Bravo { get; }
+
+            internal SimpleImmutableObject Charlie { get; }
+        }
+
         [TestMethod]
         [AutoData]
         public void Revise_creates_new_object_with_new_property_value(
@@ -194,6 +228,46 @@
         {
             ImmutableArray<string> actual = seed.Revise(x => x[1] == element);
             actual[1].Should().Be(element);
+        }
+
+        [TestMethod]
+        [AutoData]
+        public void Revise_updates_element_with_internal_constructor(
+            Guid alfa,
+            int bravo,
+            SimpleImmutableObject charlie,
+            SimpleImmutableObject expected)
+        {
+            // Arrange
+            var source = new ImmutableObjectWithInternalConstuctor(alfa, bravo, charlie);
+
+            // Act
+            var actual = source.Revise(x => x.Charlie == expected);
+
+            // Assert
+            actual.Alfa.Should().Be(alfa);
+            actual.Bravo.Should().Be(bravo);
+            actual.Charlie.Should().BeEquivalentTo(expected);
+        }
+
+        [TestMethod]
+        [AutoData]
+        public void Revise_updates_element_with_internal_properties(
+            Guid alfa,
+            int bravo,
+            SimpleImmutableObject charlie,
+            SimpleImmutableObject expected)
+        {
+            // Arrange
+            var source = new ImmutableObjectWithInternalProperties(alfa, bravo, charlie);
+
+            // Act
+            var actual = source.Revise(x => x.Charlie == expected);
+
+            // Assert
+            actual.Alfa.Should().Be(alfa);
+            actual.Bravo.Should().Be(bravo);
+            actual.Charlie.Should().BeEquivalentTo(expected);
         }
     }
 }

--- a/source/AutoReviser/ConstructorResolver.cs
+++ b/source/AutoReviser/ConstructorResolver.cs
@@ -8,6 +8,6 @@
     {
         // TODO: Cache the constructor instance.
         public static ConstructorInfo Resolve<T>()
-            => typeof(T).GetConstructors(Public | Instance).Single();
+            => typeof(T).GetConstructors(Public | Instance | NonPublic).Single();
     }
 }

--- a/source/AutoReviser/SeedVisitor.cs
+++ b/source/AutoReviser/SeedVisitor.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Generic;
     using System.Reflection;
+    using static System.Reflection.BindingFlags;
 
     internal struct SeedVisitor
     {
@@ -11,7 +12,9 @@
 
         public void Visit(object seed)
         {
-            PropertyInfo[] properties = seed.GetType().GetProperties();
+            PropertyInfo[] properties = seed
+                .GetType()
+                .GetProperties(Public | Instance | NonPublic);
             Visit(properties, instance: seed);
         }
 


### PR DESCRIPTION
AutoReviser can revise entity with non public access modifier
constructor and properties.